### PR TITLE
Fix a duplicate character in the `urlSafeCharacters` list

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const crypto = require('crypto');
 
-const urlSafeCharacters = 'abcdefjhijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~'.split('');
+const urlSafeCharacters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~'.split('');
 
 const generateForCustomCharacters = (length, characters) => {
 	// Generating entropy is faster than complex math operations, so we use the simplest way

--- a/test.js
+++ b/test.js
@@ -1,11 +1,23 @@
 import test from 'ava';
 import cryptoRandomString from '.';
 
+// Probailistic, result is always less than or equal to actual set size, chance it is less is below 1e-256 for sizes up to 32656
+const generatedCharacterSetSize = (opts, targetSize) => {
+	const set = new Set();
+	const length = targetSize * 640;
+	let string = cryptoRandomString({...opts, length});
+	for(let i = 0; i < length; i++) {
+		set.add(string[i]);
+	}
+	return set.size;
+};
+
 test('main', t => {
 	t.is(cryptoRandomString({length: 0}).length, 0);
 	t.is(cryptoRandomString({length: 10}).length, 10);
 	t.is(cryptoRandomString({length: 100}).length, 100);
 	t.regex(cryptoRandomString({length: 100}), /^[a-f\d]*$/); // Sanity check, probabilistic
+	t.is(generatedCharacterSetSize({}, 16), 16);
 });
 
 test('hex', t => {
@@ -13,6 +25,7 @@ test('hex', t => {
 	t.is(cryptoRandomString({length: 10, type: 'hex'}).length, 10);
 	t.is(cryptoRandomString({length: 100, type: 'hex'}).length, 100);
 	t.regex(cryptoRandomString({length: 100, type: 'hex'}), /^[a-f\d]*$/); // Sanity check, probabilistic
+	t.is(generatedCharacterSetSize({type: 'hex'}, 16), 16);
 });
 
 test('base64', t => {
@@ -20,6 +33,7 @@ test('base64', t => {
 	t.is(cryptoRandomString({length: 10, type: 'base64'}).length, 10);
 	t.is(cryptoRandomString({length: 100, type: 'base64'}).length, 100);
 	t.regex(cryptoRandomString({length: 100, type: 'base64'}), /^[a-zA-Z\d/+]*$/); // Sanity check, probabilistic
+	t.is(generatedCharacterSetSize({type: 'base64'}, 64), 64);
 });
 
 test('url-safe', t => {
@@ -27,6 +41,7 @@ test('url-safe', t => {
 	t.is(cryptoRandomString({length: 10, type: 'url-safe'}).length, 10);
 	t.is(cryptoRandomString({length: 100, type: 'url-safe'}).length, 100);
 	t.regex(cryptoRandomString({length: 100, type: 'url-safe'}), /^[a-zA-Z\d._~-]*$/); // Sanity check, probabilistic
+	t.is(generatedCharacterSetSize({type: 'url-safe'}, 66), 66);
 });
 
 test('characters', t => {
@@ -34,6 +49,8 @@ test('characters', t => {
 	t.is(cryptoRandomString({length: 10, characters: '1234'}).length, 10);
 	t.is(cryptoRandomString({length: 100, characters: '1234'}).length, 100);
 	t.regex(cryptoRandomString({length: 100, characters: '1234'}), /^[1-4]*$/); // Sanity check, probabilistic
+	t.is(generatedCharacterSetSize({characters: '1234'}, 4), 4);
+	t.is(generatedCharacterSetSize({characters: '0123456789'}, 10), 10);
 });
 
 test('argument errors', t => {

--- a/test.js
+++ b/test.js
@@ -5,10 +5,12 @@ import cryptoRandomString from '.';
 const generatedCharacterSetSize = (opts, targetSize) => {
 	const set = new Set();
 	const length = targetSize * 640;
-	let string = cryptoRandomString({...opts, length});
-	for(let i = 0; i < length; i++) {
+	const string = cryptoRandomString({...opts, length});
+
+	for (let i = 0; i < length; i++) {
 		set.add(string[i]);
 	}
+
 	return set.size;
 };
 

--- a/test.js
+++ b/test.js
@@ -2,10 +2,10 @@ import test from 'ava';
 import cryptoRandomString from '.';
 
 // Probailistic, result is always less than or equal to actual set size, chance it is less is below 1e-256 for sizes up to 32656
-const generatedCharacterSetSize = (opts, targetSize) => {
+const generatedCharacterSetSize = (options, targetSize) => {
 	const set = new Set();
 	const length = targetSize * 640;
-	const string = cryptoRandomString({...opts, length});
+	const string = cryptoRandomString({...options, length});
 
 	for (let i = 0; i < length; i++) {
 		set.add(string[i]);


### PR DESCRIPTION
Correct url safe characters list.

Added tests against the issue. They are probabilistic and sometimes can give false negative, but if my math is correct it is unexpected to happen in lifetime of universe.

Fixes #9