### PR TITLE
Add `distinguishable` character set

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,9 +10,9 @@ interface BaseOptions {
 interface TypeOption {
 	/**
 	Use only characters from a predefined set of allowed characters.
-	
+
 	Cannot be set at the same time as the `characters` option.
-	
+
 	@default 'hex'
 
 	The `distinguishable` set contains only uppercase characters that are not easily confused: `CDEHKMPRTUWXY012458`. It can be useful if you need to print out a short string that you'd like users to read and type back in with minimal errors. For example, reading a code off of a screen that needs to be typed into a phone to connect two devices.

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,14 @@ interface TypeOption {
 	/**
 	Use only characters from a predefined set of allowed characters.
 
+	"distinguishable" set contains only uppercase characters are not easily confused:
+
+    CDEHKMPRTUWXY012458
+
+	The distinguishable character set is useful if you need to print out a short
+	string that you'd like user's to read and type back in with minimal errors. For
+	example, reading a code off of a screen that needs to be typed into a phone to
+	connect the two devices.
 	Cannot be set at the same time as the `characters` option.
 
 	@default 'hex'
@@ -28,9 +36,13 @@ interface TypeOption {
 
 	cryptoRandomString({length: 10, type: 'numeric'});
 	//=> '8314659141'
+
+	cryptoRandomString({length: 6, type: 'distinguishable'});
+	//=> 'CDEHKM'
 	```
 	*/
-	type?: 'hex' | 'base64' | 'url-safe' | 'numeric';
+
+	type?: 'hex' | 'base64' | 'url-safe' | 'numeric' | 'distinguishable';
 }
 
 interface CharactersOption {

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,6 @@ interface TypeOption {
 	//=> 'CDEHKM'
 	```
 	*/
-
 	type?: 'hex' | 'base64' | 'url-safe' | 'numeric' | 'distinguishable';
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,18 +10,12 @@ interface BaseOptions {
 interface TypeOption {
 	/**
 	Use only characters from a predefined set of allowed characters.
-
-	"distinguishable" set contains only uppercase characters are not easily confused:
-
-    CDEHKMPRTUWXY012458
-
-	The distinguishable character set is useful if you need to print out a short
-	string that you'd like user's to read and type back in with minimal errors. For
-	example, reading a code off of a screen that needs to be typed into a phone to
-	connect the two devices.
+	
 	Cannot be set at the same time as the `characters` option.
-
+	
 	@default 'hex'
+
+	The `distinguishable` set contains only uppercase characters that are not easily confused: `CDEHKMPRTUWXY012458`. It can be useful if you need to print out a short string that you'd like users to read and type back in with minimal errors. For example, reading a code off of a screen that needs to be typed into a phone to connect two devices.
 
 	@example
 	```

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const crypto = require('crypto');
 
 const urlSafeCharacters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~'.split('');
 const numericCharacters = '0123456789'.split('');
+const distinguishableCharacters = 'CDEHKMPRTUWXY012458'.split('');
 
 const generateForCustomCharacters = (length, characters) => {
 	// Generating entropy is faster than complex math operations, so we use the simplest way
@@ -36,7 +37,8 @@ const allowedTypes = [
 	'hex',
 	'base64',
 	'url-safe',
-	'numeric'
+	'numeric',
+	'distinguishable'
 ];
 
 module.exports = ({length, type, characters}) => {
@@ -74,6 +76,10 @@ module.exports = ({length, type, characters}) => {
 
 	if (type === 'numeric') {
 		return generateForCustomCharacters(length, numericCharacters);
+	}
+
+	if (type === 'distinguishable') {
+		return generateForCustomCharacters(length, distinguishableCharacters);
 	}
 
 	if (characters.length === 0) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "sindresorhus.com"
 	},
+  "contributors": [
+    "Mark Stosberg <mark@rideamigos.com>"
+  ],
 	"engines": {
 		"node": ">=8"
 	},

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "sindresorhus.com"
 	},
-  "contributors": [
-    "Mark Stosberg <mark@rideamigos.com>"
-  ],
 	"engines": {
 		"node": ">=8"
 	},

--- a/readme.md
+++ b/readme.md
@@ -27,11 +27,11 @@ cryptoRandomString({length: 10, type: 'url-safe'});
 cryptoRandomString({length: 10, type: 'numeric'});
 //=> '8314659141'
 
-cryptoRandomString({length: 10, characters: 'abc'});
-//=> 'abaaccabac'
-
 cryptoRandomString({length: 6, type: 'distinguishable'});
 //=> 'CDEHKM'
+
+cryptoRandomString({length: 10, characters: 'abc'});
+//=> 'abaaccabac'
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -58,16 +58,10 @@ Default: `'hex'`\
 Values: `'hex' | 'base64' | 'url-safe' | 'numeric' | 'distinguishable'`
 
 Use only characters from a predefined set of allowed characters.
-"distinguishable" set contains only uppercase characters are not easily confused:
 
-    CDEHKMPRTUWXY012458
+Cannot be set at the same time as the `characters` option.
 
-The distinguishable character set is useful if you need to print out a short
-string that you'd like user's to read and type back in with minimal errors. For
-example, reading a code off of a screen that needs to be typed into a phone to
-connect the two devices.
-
-`type` cannot be set at the same time as the `characters` option.
+The `distinguishable` set contains only uppercase characters that are not easily confused: `CDEHKMPRTUWXY012458`. It can be useful if you need to print out a short string that you'd like users to read and type back in with minimal errors. For example, reading a code off of a screen that needs to be typed into a phone to connect two devices.
 
 ##### characters
 

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,9 @@ cryptoRandomString({length: 10, type: 'numeric'});
 
 cryptoRandomString({length: 10, characters: 'abc'});
 //=> 'abaaccabac'
+
+cryptoRandomString({length: 6, type: 'distinguishable'});
+//=> 'CDEHKM'
 ```
 
 ## API
@@ -52,11 +55,19 @@ Length of the returned string.
 
 Type: `string`\
 Default: `'hex'`\
-Values: `'hex' | 'base64' | 'url-safe' | 'numeric'`
+Values: `'hex' | 'base64' | 'url-safe' | 'numeric' | 'distinguishable'`
 
 Use only characters from a predefined set of allowed characters.
+"distinguishable" set contains only uppercase characters are not easily confused:
 
-Cannot be set at the same time as the `characters` option.
+    CDEHKMPRTUWXY012458
+
+The distinguishable character set is useful if you need to print out a short
+string that you'd like user's to read and type back in with minimal errors. For
+example, reading a code off of a screen that needs to be typed into a phone to
+connect the two devices.
+
+`type` cannot be set at the same time as the `characters` option.
 
 ##### characters
 

--- a/test.js
+++ b/test.js
@@ -54,6 +54,14 @@ test('numeric', t => {
 	t.is(generatedCharacterSetSize({type: 'numeric'}, 10), 10);
 });
 
+test('distinquishable', t => {
+	t.is(cryptoRandomString({length: 0, type: 'distinguishable'}).length, 0);
+	t.is(cryptoRandomString({length: 10, type: 'distinguishable'}).length, 10);
+	t.is(cryptoRandomString({length: 100, type: 'distinguishable'}).length, 100);
+	t.regex(cryptoRandomString({length: 100, type: 'distinguishable'}), /^[CDEHKMPRTUWXY012458]*$/); // Sanity check, probabilistic
+	t.is(generatedCharacterSetSize({type: 'distinguishable'}, 19), 19);
+});
+
 test('characters', t => {
 	t.is(cryptoRandomString({length: 0, characters: '1234'}).length, 0);
 	t.is(cryptoRandomString({length: 10, characters: '1234'}).length, 10);


### PR DESCRIPTION
This is a port of the "distinguishable" character set from the
distinquishable module, which is not crypto-secure:
https://github.com/komola/distinguishable

Sometimes you need to generate a random "Connect Code" that people need
to type in, and you want to remove all characters which may look
confusingly similar.