### PR TITLE
Add `numeric` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ interface TypeOption {
 	//=> 'VEjfNW3Yej'
 	```
 	*/
-	type?: 'hex' | 'base64' | 'url-safe';
+	type?: 'hex' | 'base64' | 'url-safe' | 'numeric';
 }
 
 interface CharactersOption {

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,11 +20,14 @@ interface TypeOption {
 	cryptoRandomString({length: 10});
 	//=> '87fc70e2b9'
 
-	cryptoRandomString({length: 10, type:'base64'});
+	cryptoRandomString({length: 10, type: 'base64'});
 	//=> 'mhsX7xmIv/'
 
-	cryptoRandomString({length: 10, type:'url-safe'});
+	cryptoRandomString({length: 10, type: 'url-safe'});
 	//=> 'VEjfNW3Yej'
+
+	cryptoRandomString({length: 10, type: 'numeric'});
+	//=> '8314659141'
 	```
 	*/
 	type?: 'hex' | 'base64' | 'url-safe' | 'numeric';
@@ -41,7 +44,7 @@ interface CharactersOption {
 
 	@example
 	```
-	cryptoRandomString({length: 10, characters:'0123456789'});
+	cryptoRandomString({length: 10, characters: '0123456789'});
 	//=> '8796225811'
 	```
 	*/

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const crypto = require('crypto');
 
 const urlSafeCharacters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~'.split('');
+const numericCharacters = '0123456789'.split('');
 
 const generateForCustomCharacters = (length, characters) => {
 	// Generating entropy is faster than complex math operations, so we use the simplest way
@@ -34,7 +35,8 @@ const allowedTypes = [
 	undefined,
 	'hex',
 	'base64',
-	'url-safe'
+	'url-safe',
+	'numeric'
 ];
 
 module.exports = ({length, type, characters}) => {
@@ -68,6 +70,10 @@ module.exports = ({length, type, characters}) => {
 
 	if (type === 'url-safe') {
 		return generateForCustomCharacters(length, urlSafeCharacters);
+	}
+
+	if (type === 'numeric') {
+		return generateForCustomCharacters(length, numericCharacters);
 	}
 
 	if (characters.length === 0) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,7 +3,10 @@ import cryptoRandomString = require('.');
 
 expectType<string>(cryptoRandomString({length: 10}));
 expectType<string>(cryptoRandomString({length: 10, type: 'url-safe'}));
+expectType<string>(cryptoRandomString({length: 10, type: 'numeric'}));
 expectType<string>(cryptoRandomString({length: 10, characters: '1234'}));
 
 expectError(cryptoRandomString({type: 'url-safe'}));
 expectError(cryptoRandomString({length: 10, type: 'url-safe', characters: '1234'}));
+expectError(cryptoRandomString({type: 'numeric'}));
+expectError(cryptoRandomString({length: 10, type: 'numeric', characters: '1234'}));

--- a/readme.md
+++ b/readme.md
@@ -26,8 +26,11 @@ cryptoRandomString({length: 10, type: 'base64'});
 cryptoRandomString({length: 10, type: 'url-safe'});
 //=> 'YN-tqc8pOw'
 
-cryptoRandomString({length: 10, characters: '1234567890'});
-//=> '1791935639'
+cryptoRandomString({length: 10, type: 'numeric'});
+//=> '8314659141'
+
+cryptoRandomString({length: 10, characters: 'abc'});
+//=> 'abaaccabac'
 ```
 
 
@@ -52,7 +55,7 @@ Length of the returned string.
 
 Type: `string`<br>
 Default: `'hex'`<br>
-Values: `'hex'` `'base64'` `'url-safe'`
+Values: `'hex'` `'base64'` `'url-safe'` `'numeric'`
 
 Use only characters from a predefined set of allowed characters.
 

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import cryptoRandomString from '.';
 
-// Probailistic, result is always less than or equal to actual set size, chance it is less is below 1e-256 for sizes up to 32656
+// Probabilistic, result is always less than or equal to actual set size, chance it is less is below 1e-256 for sizes up to 32656
 const generatedCharacterSetSize = (options, targetSize) => {
 	const set = new Set();
 	const length = targetSize * 640;
@@ -44,6 +44,14 @@ test('url-safe', t => {
 	t.is(cryptoRandomString({length: 100, type: 'url-safe'}).length, 100);
 	t.regex(cryptoRandomString({length: 100, type: 'url-safe'}), /^[a-zA-Z\d._~-]*$/); // Sanity check, probabilistic
 	t.is(generatedCharacterSetSize({type: 'url-safe'}, 66), 66);
+});
+
+test('numeric', t => {
+	t.is(cryptoRandomString({length: 0, type: 'numeric'}).length, 0);
+	t.is(cryptoRandomString({length: 10, type: 'numeric'}).length, 10);
+	t.is(cryptoRandomString({length: 100, type: 'numeric'}).length, 100);
+	t.regex(cryptoRandomString({length: 100, type: 'numeric'}), /^[\d]*$/); // Sanity check, probabilistic
+	t.is(generatedCharacterSetSize({type: 'numeric'}, 10), 10);
 });
 
 test('characters', t => {


### PR DESCRIPTION
We would like to use this library to generate PIN numbers, which users must type on a numeric keypad (a separate hardware device). As it stands, we would need to use:

```js
cryptoRandomString({ length: 4, characters: '0123456789' });
```

everywhere we do this.

My concern about this approach is it's easy to accidentally delete one character in the character set, and we'd end up with something like:

```js
cryptoRandomString({ length: 4, characters: '012345789' });
```

Which at a glance you wouldn't notice is not actually the full numeric set and exponentially decreases the security of the generated PINs. I'd prefer to do:

```js
cryptoRandomString({ length: 4, type: 'numeric' });
```

As this seems more readable to me, as well as throwing an error at runtime if it's subtly broken instead of just silently becoming less secure. We also use Typescript, so we'd see the error in the `type` option immediately as well.

Edit: I also fixed a typo in a comment, forgot to mention that.