### PR TITLE
Use es6-promisify in favor of core util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const {promisify} = require('util');
+const {promisify} = require('es6-promisify');
 const crypto = require('crypto');
 
 const randomBytesAsync = promisify(crypto.randomBytes);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"protect"
 	],
 	"dependencies": {
+		"es6-promisify": "^6.1.1",
 		"type-fest": "^0.8.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Extremely small tweak to use a package-based version of `promisify`.  Drop in replacement for the version from `util`.  Provides a standard experience across different node versions.

Also, when using this in browsers with webpack v5, the polyfill for `util` is currently broken and doesn't look like it will be fixed anytime soon ([browserify/node-util#43](https://github.com/browserify/node-util/issues/43)).  So that's an extra reason to use this package instead, at least for the time being!